### PR TITLE
fix: update useLastFM dependency to avoid errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "react-scripts": "4.0.1",
     "styled-components": "^5.2.1",
     "typescript": "^4.1.3",
-    "use-last-fm": "^0.2.11",
+    "use-last-fm": "0.6.0",
     "web-vitals": "^0.2.4"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4156,6 +4156,11 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+dequal@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
+
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
@@ -10543,6 +10548,13 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+swr@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-0.4.2.tgz#4a9ed5e9948088af145c79d716d294cb99712a29"
+  integrity sha512-SKGxcAfyijj/lE5ja5zVMDqJNudASH3WZPRUakDVOePTM18FnsXgugndjl9BSRwj+jokFCulMDe7F2pQL+VhEw==
+  dependencies:
+    dequal "2.0.2"
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -11037,10 +11049,12 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-last-fm@^0.2.11:
-  version "0.2.11"
-  resolved "https://registry.yarnpkg.com/use-last-fm/-/use-last-fm-0.2.11.tgz#78c7b1efaea6717b13d25c34a62584bd39e7f58a"
-  integrity sha512-+59M4Zx7gYG1FO2eWp0GyGTLzN9Zs6t/USY3iv5ZUmkRGBkdH6/7HfMyq+tu2wWrBqtnKEm9T4oUQ6s6ywONRw==
+use-last-fm@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/use-last-fm/-/use-last-fm-0.6.0.tgz#e5b572f77c46e53f0bcd0e8743c60818d1f97c1d"
+  integrity sha512-HYefHW6VnbfztR/h6A0ILkD7ScgqXiKi6nOYlh92bwO7Jf8xUL3S/LQ9qCFOA8qHWyDHjFHUUUDjlMQPjM8g2g==
+  dependencies:
+    swr "^0.4.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
useLastFM dependency lacked any error handling in earlier versions, so upgraded the dependency to include this.

After having just cloned this repository and done `yarn && yarn start` you are greeted with a nice error message.

![Screenshot from 2021-07-08 13-03-30](https://user-images.githubusercontent.com/7765599/124911715-5dddeb00-dfed-11eb-9694-d5de6023155f.png)

After doing some research and finding out that useLastFM dependency had added error handling, I update the dependency so that it would not crash.

![Screenshot from 2021-07-08 13-04-24](https://user-images.githubusercontent.com/7765599/124911801-7948f600-dfed-11eb-80c5-7531fcb9e0f6.png)
