### PR TITLE
fix: setInterval keeps adding more intervals

### DIFF
--- a/src/views/widget.tsx
+++ b/src/views/widget.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import dayjs from "dayjs";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useLastFM } from "use-last-fm";
 import { useLocation } from "react-router-dom";
 
@@ -154,10 +154,18 @@ const Widget = ({
     token || params.get("token") || ""
   );
 
-  if (!isShowTime)
-    setInterval(() => {
-      setTime(dayjs().format("H:mm:ss"));
-    }, 1000);
+  useEffect(() => {
+    let interval: number;
+    if (!isShowTime) {
+      setInterval(() => {
+        setTime(dayjs().format("H:mm:ss"));
+      }, 1000);
+    }
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [isShowTime]);
 
   return (
     <Column


### PR DESCRIPTION
Wrapped the setInterval in a useEffect so that it doesn't keep adding more and more intervals on each tick of the clock.

Before

![useinterval_before](https://user-images.githubusercontent.com/7765599/124927235-b2d62d00-dffe-11eb-93e4-070955cb6314.gif)

After

![useinterval_after](https://user-images.githubusercontent.com/7765599/124927250-b8cc0e00-dffe-11eb-91c9-089ae2908a60.gif)
